### PR TITLE
SNOW-1011780: `spcs service set/unset <properties...>` commands

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -12,7 +12,7 @@
   * Added `image-repository url <repo_name>` command to get the URL for specified image repository.
   * Added `create` command for `image-repository`.
   * Added `set (property)`, `unset (property)`, `suspend` and `resume` commands for `compute-pool`.
-  * Added `upgrade` and `list-endpoints` commands for `service`.
+  * Added `set (property)`, `unset (property)`,`upgrade` and `list-endpoints` commands for `service`.
 
 ## Fixes and improvements
 * Restricted permissions of automatically created files

--- a/src/snowflake/cli/plugins/spcs/common.py
+++ b/src/snowflake/cli/plugins/spcs/common.py
@@ -77,5 +77,5 @@ def handle_object_already_exists(
         raise error
 
 
-class NoPropertiesProvidedError(ValueError):
+class NoPropertiesProvidedError(ClickException):
     pass

--- a/src/snowflake/cli/plugins/spcs/compute_pool/commands.py
+++ b/src/snowflake/cli/plugins/spcs/compute_pool/commands.py
@@ -10,7 +10,6 @@ from snowflake.cli.api.output.types import CommandResult, SingleQueryResult
 from snowflake.cli.api.project.util import is_valid_object_name
 from snowflake.cli.plugins.object.common import CommentOption
 from snowflake.cli.plugins.spcs.common import (
-    NoPropertiesProvidedError,
     validate_and_set_instances,
 )
 from snowflake.cli.plugins.spcs.compute_pool.manager import ComputePoolManager
@@ -142,20 +141,15 @@ def set_property(
     """
     Sets one or more properties or parameters for the compute pool.
     """
-    try:
-        cursor = ComputePoolManager().set_property(
-            pool_name=name,
-            min_nodes=min_nodes,
-            max_nodes=max_nodes,
-            auto_resume=auto_resume,
-            auto_suspend_secs=auto_suspend_secs,
-            comment=comment,
-        )
-        return SingleQueryResult(cursor)
-    except NoPropertiesProvidedError:
-        raise ClickException(
-            f"No properties specified for compute pool '{name}'. Please provide at least one property to set."
-        )
+    cursor = ComputePoolManager().set_property(
+        pool_name=name,
+        min_nodes=min_nodes,
+        max_nodes=max_nodes,
+        auto_resume=auto_resume,
+        auto_suspend_secs=auto_suspend_secs,
+        comment=comment,
+    )
+    return SingleQueryResult(cursor)
 
 
 @app.command("unset", requires_connection=True)
@@ -182,15 +176,10 @@ def unset_property(
     """
     Resets one or more properties or parameters for the compute pool to their default value(s).
     """
-    try:
-        cursor = ComputePoolManager().unset_property(
-            pool_name=name,
-            auto_resume=auto_resume,
-            auto_suspend_secs=auto_suspend_secs,
-            comment=comment,
-        )
-        return SingleQueryResult(cursor)
-    except NoPropertiesProvidedError:
-        raise ClickException(
-            f"No properties specified for compute pool '{name}'. Please provide at least one property to reset to its default value."
-        )
+    cursor = ComputePoolManager().unset_property(
+        pool_name=name,
+        auto_resume=auto_resume,
+        auto_suspend_secs=auto_suspend_secs,
+        comment=comment,
+    )
+    return SingleQueryResult(cursor)

--- a/src/snowflake/cli/plugins/spcs/compute_pool/manager.py
+++ b/src/snowflake/cli/plugins/spcs/compute_pool/manager.py
@@ -65,6 +65,8 @@ class ComputePoolManager(SqlExecutionMixin):
             ("auto_suspend_secs", auto_suspend_secs),
             ("comment", comment),
         ]
+
+        # Check if all provided properties are set to None (no properties are being set)
         if all([value is None for property_name, value in property_pairs]):
             raise NoPropertiesProvidedError(
                 f"No properties specified for compute pool '{pool_name}'. Please provide at least one property to set."
@@ -83,6 +85,8 @@ class ComputePoolManager(SqlExecutionMixin):
             ("auto_suspend_secs", auto_suspend_secs),
             ("comment", comment),
         ]
+
+        # Check if all properties provided are False (no properties are being unset)
         if not any([value for property_name, value in property_pairs]):
             raise NoPropertiesProvidedError(
                 f"No properties specified for compute pool '{pool_name}'. Please provide at least one property to reset to its default value."

--- a/src/snowflake/cli/plugins/spcs/compute_pool/manager.py
+++ b/src/snowflake/cli/plugins/spcs/compute_pool/manager.py
@@ -67,7 +67,7 @@ class ComputePoolManager(SqlExecutionMixin):
         ]
         if all([value is None for property_name, value in property_pairs]):
             raise NoPropertiesProvidedError(
-                "at least one of the properties passed to 'set_property' must not be None"
+                f"No properties specified for compute pool '{pool_name}'. Please provide at least one property to set."
             )
         query: List[str] = [f"alter compute pool {pool_name} set"]
         for property_name, value in property_pairs:
@@ -85,7 +85,7 @@ class ComputePoolManager(SqlExecutionMixin):
         ]
         if not any([value for property_name, value in property_pairs]):
             raise NoPropertiesProvidedError(
-                "at least one of the properties passed to 'unset_property' must be True"
+                f"No properties specified for compute pool '{pool_name}'. Please provide at least one property to reset to its default value."
             )
         unset_list = [property_name for property_name, value in property_pairs if value]
         query = f"alter compute pool {pool_name} unset {','.join(unset_list)}"

--- a/src/snowflake/cli/plugins/spcs/services/commands.py
+++ b/src/snowflake/cli/plugins/spcs/services/commands.py
@@ -4,15 +4,15 @@ from typing import List, Optional
 
 import typer
 from click import ClickException
+from snowflake.cli.api.commands.flags import (
+    OverrideableOption,
+)
 from snowflake.cli.api.commands.snow_typer import SnowTyper
 from snowflake.cli.api.output.types import (
     CommandResult,
     QueryJsonValueResult,
     QueryResult,
     SingleQueryResult,
-)
-from snowflake.cli.api.commands.flags import (
-    OverrideableOption,
 )
 from snowflake.cli.api.project.util import is_valid_object_name
 from snowflake.cli.plugins.object.common import CommentOption, Tag, TagOption
@@ -91,7 +91,7 @@ def create(
         help="Identifies External Access Integrations(EAI) that the service can access. This option may be specified multiple times for multiple EAIs.",
     ),
     query_warehouse: Optional[str] = QueryWarehouseOption(),
-    tags: Optional[List[str]] = TagOption(help="Tag for the service."),
+    tags: Optional[List[Tag]] = TagOption(help="Tag for the service."),
     comment: Optional[str] = CommentOption(help=_COMMENT_HELP),
     **options,
 ) -> CommandResult:

--- a/src/snowflake/cli/plugins/spcs/services/commands.py
+++ b/src/snowflake/cli/plugins/spcs/services/commands.py
@@ -197,6 +197,9 @@ def set_property(
     comment: Optional[str] = CommentOption(help=_COMMENT_HELP, show_default=False),
     **options,
 ):
+    """
+    Sets one or more properties or parameters for the service.
+    """
     try:
         cursor = ServiceManager().set_property(
             service_name=name,
@@ -245,6 +248,9 @@ def unset_property(
     ),
     **options,
 ):
+    """
+    Resets one or more properties or parameters for the service to their default value(s).
+    """
     try:
         cursor = ServiceManager().unset_property(
             service_name=name,

--- a/src/snowflake/cli/plugins/spcs/services/commands.py
+++ b/src/snowflake/cli/plugins/spcs/services/commands.py
@@ -195,6 +195,7 @@ def set_property(
     query_warehouse: Optional[str] = QueryWarehouseOption(show_default=False),
     auto_resume: Optional[bool] = AutoResumeOption(default=None, show_default=False),
     comment: Optional[str] = CommentOption(help=_COMMENT_HELP, show_default=False),
+    **options,
 ):
     try:
         cursor = ServiceManager().set_property(
@@ -239,8 +240,10 @@ def unset_property(
     comment: bool = CommentOption(
         default=False,
         help=f"Reset the COMMENT property - {_COMMENT_HELP}",
+        callback=None,
         show_default=False,
     ),
+    **options,
 ):
     try:
         cursor = ServiceManager().unset_property(

--- a/src/snowflake/cli/plugins/spcs/services/commands.py
+++ b/src/snowflake/cli/plugins/spcs/services/commands.py
@@ -17,7 +17,6 @@ from snowflake.cli.api.output.types import (
 from snowflake.cli.api.project.util import is_valid_object_name
 from snowflake.cli.plugins.object.common import CommentOption, Tag, TagOption
 from snowflake.cli.plugins.spcs.common import (
-    NoPropertiesProvidedError,
     print_log_lines,
     validate_and_set_instances,
 )
@@ -200,20 +199,15 @@ def set_property(
     """
     Sets one or more properties or parameters for the service.
     """
-    try:
-        cursor = ServiceManager().set_property(
-            service_name=name,
-            min_instances=min_instances,
-            max_instances=max_instances,
-            query_warehouse=query_warehouse,
-            auto_resume=auto_resume,
-            comment=comment,
-        )
-        return SingleQueryResult(cursor)
-    except NoPropertiesProvidedError:
-        raise ClickException(
-            f"No properties specified for service '{name}'. Please provide at least one property to set."
-        )
+    cursor = ServiceManager().set_property(
+        service_name=name,
+        min_instances=min_instances,
+        max_instances=max_instances,
+        query_warehouse=query_warehouse,
+        auto_resume=auto_resume,
+        comment=comment,
+    )
+    return SingleQueryResult(cursor)
 
 
 @app.command("unset", requires_connection=True)
@@ -251,17 +245,12 @@ def unset_property(
     """
     Resets one or more properties or parameters for the service to their default value(s).
     """
-    try:
-        cursor = ServiceManager().unset_property(
-            service_name=name,
-            min_instances=min_instances,
-            max_instances=max_instances,
-            query_warehouse=query_warehouse,
-            auto_resume=auto_resume,
-            comment=comment,
-        )
-        return SingleQueryResult(cursor)
-    except NoPropertiesProvidedError:
-        raise ClickException(
-            f"No properties specified for service '{name}'. Please provide at least one property to reset to its default value."
-        )
+    cursor = ServiceManager().unset_property(
+        service_name=name,
+        min_instances=min_instances,
+        max_instances=max_instances,
+        query_warehouse=query_warehouse,
+        auto_resume=auto_resume,
+        comment=comment,
+    )
+    return SingleQueryResult(cursor)

--- a/src/snowflake/cli/plugins/spcs/services/commands.py
+++ b/src/snowflake/cli/plugins/spcs/services/commands.py
@@ -11,9 +11,13 @@ from snowflake.cli.api.output.types import (
     QueryResult,
     SingleQueryResult,
 )
+from snowflake.cli.api.commands.flags import (
+    OverrideableOption,
+)
 from snowflake.cli.api.project.util import is_valid_object_name
 from snowflake.cli.plugins.object.common import CommentOption, Tag, TagOption
 from snowflake.cli.plugins.spcs.common import (
+    NoPropertiesProvidedError,
     print_log_lines,
     validate_and_set_instances,
 )
@@ -44,6 +48,32 @@ SpecPathOption = typer.Option(
     exists=True,
 )
 
+_MIN_INSTANCES_HELP = "Minimum number of service instances to run."
+MinInstancesOption = OverrideableOption(
+    1, "--min-instances", help=_MIN_INSTANCES_HELP, min=1
+)
+
+_MAX_INSTANCES_HELP = "Maximum number of service instances to run."
+MaxInstancesOption = OverrideableOption(
+    None, "--max-instances", help=_MAX_INSTANCES_HELP, min=1
+)
+
+_QUERY_WAREHOUSE_HELP = "Warehouse to use if a service container connects to Snowflake to execute a query without explicitly specifying a warehouse to use."
+QueryWarehouseOption = OverrideableOption(
+    None,
+    "--query-warehouse",
+    help=_QUERY_WAREHOUSE_HELP,
+)
+
+_AUTO_RESUME_HELP = "The service will automatically resume when a service function or ingress is called."
+AutoResumeOption = OverrideableOption(
+    True,
+    "--auto-resume/--no-auto-resume",
+    help=_AUTO_RESUME_HELP,
+)
+
+_COMMENT_HELP = "Comment for the service."
+
 
 @app.command(requires_connection=True)
 def create(
@@ -52,29 +82,17 @@ def create(
         ..., "--compute-pool", help="Compute pool to run the service on."
     ),
     spec_path: Path = SpecPathOption,
-    min_instances: int = typer.Option(
-        1, "--min-instances", help="Minimum number of service instances to run."
-    ),
-    max_instances: Optional[int] = typer.Option(
-        None, "--max-instances", help="Maximum number of service instances to run."
-    ),
-    auto_resume: bool = typer.Option(
-        True,
-        "--auto-resume/--no-auto-resume",
-        help="The service will automatically resume when a service function or ingress is called.",
-    ),
+    min_instances: int = MinInstancesOption(),
+    max_instances: Optional[int] = MaxInstancesOption(),
+    auto_resume: bool = AutoResumeOption(),
     external_access_integrations: Optional[List[str]] = typer.Option(
         None,
         "--eai-name",
         help="Identifies External Access Integrations(EAI) that the service can access. This option may be specified multiple times for multiple EAIs.",
     ),
-    query_warehouse: Optional[str] = typer.Option(
-        None,
-        "--query-warehouse",
-        help="Warehouse to use if a service container connects to Snowflake to execute a query without explicitly specifying a warehouse to use.",
-    ),
-    tags: Optional[List[Tag]] = TagOption(help="Tag for the service."),
-    comment: Optional[str] = CommentOption(help="Comment for the service."),
+    query_warehouse: Optional[str] = QueryWarehouseOption(),
+    tags: Optional[List[str]] = TagOption(help="Tag for the service."),
+    comment: Optional[str] = CommentOption(help=_COMMENT_HELP),
     **options,
 ) -> CommandResult:
     """
@@ -167,3 +185,74 @@ def resume(name: str = ServiceNameArgument, **options) -> CommandResult:
     Resumes the service from SUSPENDED state.
     """
     return SingleQueryResult(ServiceManager().resume(name))
+
+
+@app.command("set", requires_connection=True)
+def set_property(
+    name: str = ServiceNameArgument,
+    min_instances: Optional[int] = MinInstancesOption(default=None, show_default=False),
+    max_instances: Optional[int] = MaxInstancesOption(show_default=False),
+    query_warehouse: Optional[str] = QueryWarehouseOption(show_default=False),
+    auto_resume: Optional[bool] = AutoResumeOption(default=None, show_default=False),
+    comment: Optional[str] = CommentOption(help=_COMMENT_HELP, show_default=False),
+):
+    try:
+        cursor = ServiceManager().set_property(
+            service_name=name,
+            min_instances=min_instances,
+            max_instances=max_instances,
+            query_warehouse=query_warehouse,
+            auto_resume=auto_resume,
+            comment=comment,
+        )
+        return SingleQueryResult(cursor)
+    except NoPropertiesProvidedError:
+        raise ClickException(
+            f"No properties specified for service '{name}'. Please provide at least one property to set."
+        )
+
+
+@app.command("unset", requires_connection=True)
+def unset_property(
+    name: str = ServiceNameArgument,
+    min_instances: bool = MinInstancesOption(
+        default=False,
+        help=f"Reset the MIN_INSTANCES property - {_MIN_INSTANCES_HELP}",
+        show_default=False,
+    ),
+    max_instances: bool = MaxInstancesOption(
+        default=False,
+        help=f"Reset the MAX_INSTANCES property - {_MAX_INSTANCES_HELP}",
+        show_default=False,
+    ),
+    query_warehouse: bool = QueryWarehouseOption(
+        default=False,
+        help=f"Reset the QUERY_WAREHOUSE property - {_QUERY_WAREHOUSE_HELP}",
+        show_default=False,
+    ),
+    auto_resume: bool = AutoResumeOption(
+        default=False,
+        param_decls=["--auto-resume"],
+        help=f"Reset the AUTO_RESUME property - {_AUTO_RESUME_HELP}",
+        show_default=False,
+    ),
+    comment: bool = CommentOption(
+        default=False,
+        help=f"Reset the COMMENT property - {_COMMENT_HELP}",
+        show_default=False,
+    ),
+):
+    try:
+        cursor = ServiceManager().unset_property(
+            service_name=name,
+            min_instances=min_instances,
+            max_instances=max_instances,
+            query_warehouse=query_warehouse,
+            auto_resume=auto_resume,
+            comment=comment,
+        )
+        return SingleQueryResult(cursor)
+    except NoPropertiesProvidedError:
+        raise ClickException(
+            f"No properties specified for service '{name}'. Please provide at least one property to reset to its default value."
+        )

--- a/src/snowflake/cli/plugins/spcs/services/manager.py
+++ b/src/snowflake/cli/plugins/spcs/services/manager.py
@@ -117,7 +117,7 @@ class ServiceManager(SqlExecutionMixin):
         ]
         if all([value is None for property_name, value in property_pairs]):
             raise NoPropertiesProvidedError(
-                "at least one of the properties passed to 'set_property' must not be None"
+                f"No properties specified for service '{service_name}'. Please provide at least one property to set."
             )
         query: list[str] = [f"alter service {service_name} set"]
         for property_name, value in property_pairs:
@@ -143,7 +143,7 @@ class ServiceManager(SqlExecutionMixin):
         ]
         if not any([value for property_name, value in property_pairs]):
             raise NoPropertiesProvidedError(
-                "at least one of the properties passed to 'unset_property' must be True"
+                f"No properties specified for service '{service_name}'. Please provide at least one property to reset to its default value."
             )
         unset_list = [property_name for property_name, value in property_pairs if value]
         query = f"alter service {service_name} unset {','.join(unset_list)}"

--- a/src/snowflake/cli/plugins/spcs/services/manager.py
+++ b/src/snowflake/cli/plugins/spcs/services/manager.py
@@ -123,7 +123,7 @@ class ServiceManager(SqlExecutionMixin):
         for property_name, value in property_pairs:
             if value is not None:
                 query.append(f"{property_name} = {value}")
-        return self._execute_query(strip_empty_lines(query))
+        return self._execute_schema_query(strip_empty_lines(query))
 
     def unset_property(
         self,
@@ -147,4 +147,4 @@ class ServiceManager(SqlExecutionMixin):
             )
         unset_list = [property_name for property_name, value in property_pairs if value]
         query = f"alter service {service_name} unset {','.join(unset_list)}"
-        return self._execute_query(query)
+        return self._execute_schema_query(query)

--- a/src/snowflake/cli/plugins/spcs/services/manager.py
+++ b/src/snowflake/cli/plugins/spcs/services/manager.py
@@ -5,6 +5,7 @@ from snowflake.cli.api.constants import ObjectType
 from snowflake.cli.api.sql_execution import SqlExecutionMixin
 from snowflake.cli.plugins.object.common import Tag
 from snowflake.cli.plugins.spcs.common import (
+    NoPropertiesProvidedError,
     handle_object_already_exists,
     strip_empty_lines,
 )
@@ -97,3 +98,53 @@ class ServiceManager(SqlExecutionMixin):
 
     def resume(self, service_name: str):
         return self._execute_schema_query(f"alter service {service_name} resume")
+
+    def set_property(
+        self,
+        service_name: str,
+        min_instances: Optional[int],
+        max_instances: Optional[int],
+        query_warehouse: Optional[str],
+        auto_resume: Optional[bool],
+        comment: Optional[str],
+    ):
+        property_pairs = [
+            ("min_instances", min_instances),
+            ("max_instances", max_instances),
+            ("query_warehouse", query_warehouse),
+            ("auto_resume", auto_resume),
+            ("comment", comment),
+        ]
+        if all([value is None for property_name, value in property_pairs]):
+            raise NoPropertiesProvidedError(
+                "at least one of the properties passed to 'set_property' must not be None"
+            )
+        query: list[str] = [f"alter service {service_name} set"]
+        for property_name, value in property_pairs:
+            if value is not None:
+                query.append(f"{property_name} = {value}")
+        return self._execute_query(strip_empty_lines(query))
+
+    def unset_property(
+        self,
+        service_name: str,
+        min_instances: bool,
+        max_instances: bool,
+        query_warehouse: bool,
+        auto_resume: bool,
+        comment: bool,
+    ):
+        property_pairs = [
+            ("min_instances", min_instances),
+            ("max_instances", max_instances),
+            ("query_warehouse", query_warehouse),
+            ("auto_resume", auto_resume),
+            ("comment", comment),
+        ]
+        if not any([value for property_name, value in property_pairs]):
+            raise NoPropertiesProvidedError(
+                "at least one of the properties passed to 'unset_property' must be True"
+            )
+        unset_list = [property_name for property_name, value in property_pairs if value]
+        query = f"alter service {service_name} unset {','.join(unset_list)}"
+        return self._execute_query(query)

--- a/src/snowflake/cli/plugins/spcs/services/manager.py
+++ b/src/snowflake/cli/plugins/spcs/services/manager.py
@@ -115,6 +115,8 @@ class ServiceManager(SqlExecutionMixin):
             ("auto_resume", auto_resume),
             ("comment", comment),
         ]
+
+        # Check if all provided properties are set to None (no properties are being set)
         if all([value is None for property_name, value in property_pairs]):
             raise NoPropertiesProvidedError(
                 f"No properties specified for service '{service_name}'. Please provide at least one property to set."
@@ -141,6 +143,8 @@ class ServiceManager(SqlExecutionMixin):
             ("auto_resume", auto_resume),
             ("comment", comment),
         ]
+
+        # Check if all properties provided are False (no properties are being unset)
         if not any([value for property_name, value in property_pairs]):
             raise NoPropertiesProvidedError(
                 f"No properties specified for service '{service_name}'. Please provide at least one property to reset to its default value."

--- a/tests/__snapshots__/test_help_messages.ambr
+++ b/tests/__snapshots__/test_help_messages.ambr
@@ -3008,59 +3008,66 @@
   │ *    name      TEXT  Name of the service. [default: None] [required]         │
   ╰──────────────────────────────────────────────────────────────────────────────╯
   ╭─ Options ────────────────────────────────────────────────────────────────────╮
-  │ *  --compute-pool                             TEXT        Compute pool to    │
-  │                                                           run the service    │
-  │                                                           on.                │
-  │                                                           [default: None]    │
-  │                                                           [required]         │
-  │ *  --spec-path                                FILE        Path to service    │
-  │                                                           specification      │
-  │                                                           file.              │
-  │                                                           [default: None]    │
-  │                                                           [required]         │
-  │    --min-instances                            INTEGER     Minimum number of  │
-  │                                                           service instances  │
-  │                                                           to run.            │
-  │                                                           [default: 1]       │
-  │    --max-instances                            INTEGER     Maximum number of  │
-  │                                                           service instances  │
-  │                                                           to run.            │
-  │                                                           [default: None]    │
-  │    --auto-resume          --no-auto-resume                The service will   │
-  │                                                           automatically      │
-  │                                                           resume when a      │
-  │                                                           service function   │
-  │                                                           or ingress is      │
-  │                                                           called.            │
-  │                                                           [default:          │
-  │                                                           auto-resume]       │
-  │    --eai-name                                 TEXT        Identifies         │
-  │                                                           External Access    │
-  │                                                           Integrations(EAI)  │
-  │                                                           that the service   │
-  │                                                           can access. This   │
-  │                                                           option may be      │
-  │                                                           specified multiple │
-  │                                                           times for multiple │
-  │                                                           EAIs.              │
-  │                                                           [default: None]    │
-  │    --query-warehouse                          TEXT        Warehouse to use   │
-  │                                                           if a service       │
-  │                                                           container connects │
-  │                                                           to Snowflake to    │
-  │                                                           execute a query    │
-  │                                                           without explicitly │
-  │                                                           specifying a       │
-  │                                                           warehouse to use.  │
-  │                                                           [default: None]    │
-  │    --tag                                      NAME=VALUE  Tag for the        │
-  │                                                           service.           │
-  │                                                           [default: None]    │
-  │    --comment                                  TEXT        Comment for the    │
-  │                                                           service.           │
-  │                                                           [default: None]    │
-  │    --help             -h                                  Show this message  │
-  │                                                           and exit.          │
+  │ *  --compute-pool                          TEXT             Compute pool to  │
+  │                                                             run the service  │
+  │                                                             on.              │
+  │                                                             [default: None]  │
+  │                                                             [required]       │
+  │ *  --spec-path                             FILE             Path to service  │
+  │                                                             specification    │
+  │                                                             file.            │
+  │                                                             [default: None]  │
+  │                                                             [required]       │
+  │    --min-instances                         INTEGER RANGE    Minimum number   │
+  │                                            [x>=1]           of service       │
+  │                                                             instances to     │
+  │                                                             run.             │
+  │                                                             [default: 1]     │
+  │    --max-instances                         INTEGER RANGE    Maximum number   │
+  │                                            [x>=1]           of service       │
+  │                                                             instances to     │
+  │                                                             run.             │
+  │                                                             [default: None]  │
+  │    --auto-resume        --no-auto-resu…                     The service will │
+  │                                                             automatically    │
+  │                                                             resume when a    │
+  │                                                             service function │
+  │                                                             or ingress is    │
+  │                                                             called.          │
+  │                                                             [default:        │
+  │                                                             auto-resume]     │
+  │    --eai-name                              TEXT             Identifies       │
+  │                                                             External Access  │
+  │                                                             Integrations(EA… │
+  │                                                             that the service │
+  │                                                             can access. This │
+  │                                                             option may be    │
+  │                                                             specified        │
+  │                                                             multiple times   │
+  │                                                             for multiple     │
+  │                                                             EAIs.            │
+  │                                                             [default: None]  │
+  │    --query-wareho…                         TEXT             Warehouse to use │
+  │                                                             if a service     │
+  │                                                             container        │
+  │                                                             connects to      │
+  │                                                             Snowflake to     │
+  │                                                             execute a query  │
+  │                                                             without          │
+  │                                                             explicitly       │
+  │                                                             specifying a     │
+  │                                                             warehouse to     │
+  │                                                             use.             │
+  │                                                             [default: None]  │
+  │    --tag                                   NAME=VALUE       Tag for the      │
+  │                                                             service.         │
+  │                                                             [default: None]  │
+  │    --comment                               TEXT             Comment for the  │
+  │                                                             service.         │
+  │                                                             [default: None]  │
+  │    --help           -h                                      Show this        │
+  │                                                             message and      │
+  │                                                             exit.            │
   ╰──────────────────────────────────────────────────────────────────────────────╯
   ╭─ Connection configuration ───────────────────────────────────────────────────╮
   │ --connection,--environment  -c      TEXT  Name of the connection, as defined │
@@ -3305,6 +3312,98 @@
   
   '''
 # ---
+# name: test_help_messages[spcs.service.set]
+  '''
+                                                                                  
+   Usage: default spcs service set [OPTIONS] NAME                                 
+                                                                                  
+   Sets one or more properties or parameters for the service.                     
+                                                                                  
+  ╭─ Arguments ──────────────────────────────────────────────────────────────────╮
+  │ *    name      TEXT  Name of the service. [default: None] [required]         │
+  ╰──────────────────────────────────────────────────────────────────────────────╯
+  ╭─ Options ────────────────────────────────────────────────────────────────────╮
+  │ --min-instances                           INTEGER RANGE     Minimum number   │
+  │                                           [x>=1]            of service       │
+  │                                                             instances to     │
+  │                                                             run.             │
+  │ --max-instances                           INTEGER RANGE     Maximum number   │
+  │                                           [x>=1]            of service       │
+  │                                                             instances to     │
+  │                                                             run.             │
+  │ --query-warehouse                         TEXT              Warehouse to use │
+  │                                                             if a service     │
+  │                                                             container        │
+  │                                                             connects to      │
+  │                                                             Snowflake to     │
+  │                                                             execute a query  │
+  │                                                             without          │
+  │                                                             explicitly       │
+  │                                                             specifying a     │
+  │                                                             warehouse to     │
+  │                                                             use.             │
+  │ --auto-resume          --no-auto-resu…                      The service will │
+  │                                                             automatically    │
+  │                                                             resume when a    │
+  │                                                             service function │
+  │                                                             or ingress is    │
+  │                                                             called.          │
+  │ --comment                                 TEXT              Comment for the  │
+  │                                                             service.         │
+  │ --help             -h                                       Show this        │
+  │                                                             message and      │
+  │                                                             exit.            │
+  ╰──────────────────────────────────────────────────────────────────────────────╯
+  ╭─ Connection configuration ───────────────────────────────────────────────────╮
+  │ --connection,--environment  -c      TEXT  Name of the connection, as defined │
+  │                                           in your `config.toml`. Default:    │
+  │                                           `default`.                         │
+  │ --account,--accountname             TEXT  Name assigned to your Snowflake    │
+  │                                           account. Overrides the value       │
+  │                                           specified for the connection.      │
+  │ --user,--username                   TEXT  Username to connect to Snowflake.  │
+  │                                           Overrides the value specified for  │
+  │                                           the connection.                    │
+  │ --password                          TEXT  Snowflake password. Overrides the  │
+  │                                           value specified for the            │
+  │                                           connection.                        │
+  │ --authenticator                     TEXT  Snowflake authenticator. Overrides │
+  │                                           the value specified for the        │
+  │                                           connection.                        │
+  │ --private-key-path                  TEXT  Snowflake private key path.        │
+  │                                           Overrides the value specified for  │
+  │                                           the connection.                    │
+  │ --database,--dbname                 TEXT  Database to use. Overrides the     │
+  │                                           value specified for the            │
+  │                                           connection.                        │
+  │ --schema,--schemaname               TEXT  Database schema to use. Overrides  │
+  │                                           the value specified for the        │
+  │                                           connection.                        │
+  │ --role,--rolename                   TEXT  Role to use. Overrides the value   │
+  │                                           specified for the connection.      │
+  │ --warehouse                         TEXT  Warehouse to use. Overrides the    │
+  │                                           value specified for the            │
+  │                                           connection.                        │
+  │ --temporary-connection      -x            Uses connection defined with       │
+  │                                           command line parameters, instead   │
+  │                                           of one defined in config           │
+  │ --mfa-passcode                      TEXT  Token to use for multi-factor      │
+  │                                           authentication (MFA)               │
+  ╰──────────────────────────────────────────────────────────────────────────────╯
+  ╭─ Global configuration ───────────────────────────────────────────────────────╮
+  │ --format           [TABLE|JSON]  Specifies the output format.                │
+  │                                  [default: TABLE]                            │
+  │ --verbose  -v                    Displays log entries for log levels `info`  │
+  │                                  and higher.                                 │
+  │ --debug                          Displays log entries for log levels `debug` │
+  │                                  and higher; debug logs contains additional  │
+  │                                  information.                                │
+  │ --silent                         Turns off intermediate output to console.   │
+  ╰──────────────────────────────────────────────────────────────────────────────╯
+  
+  
+  '''
+# ---
 # name: test_help_messages[spcs.service.status]
   '''
                                                                                   
@@ -3380,6 +3479,83 @@
   ╰──────────────────────────────────────────────────────────────────────────────╯
   ╭─ Options ────────────────────────────────────────────────────────────────────╮
   │ --help  -h        Show this message and exit.                                │
+  ╰──────────────────────────────────────────────────────────────────────────────╯
+  ╭─ Connection configuration ───────────────────────────────────────────────────╮
+  │ --connection,--environment  -c      TEXT  Name of the connection, as defined │
+  │                                           in your `config.toml`. Default:    │
+  │                                           `default`.                         │
+  │ --account,--accountname             TEXT  Name assigned to your Snowflake    │
+  │                                           account. Overrides the value       │
+  │                                           specified for the connection.      │
+  │ --user,--username                   TEXT  Username to connect to Snowflake.  │
+  │                                           Overrides the value specified for  │
+  │                                           the connection.                    │
+  │ --password                          TEXT  Snowflake password. Overrides the  │
+  │                                           value specified for the            │
+  │                                           connection.                        │
+  │ --authenticator                     TEXT  Snowflake authenticator. Overrides │
+  │                                           the value specified for the        │
+  │                                           connection.                        │
+  │ --private-key-path                  TEXT  Snowflake private key path.        │
+  │                                           Overrides the value specified for  │
+  │                                           the connection.                    │
+  │ --database,--dbname                 TEXT  Database to use. Overrides the     │
+  │                                           value specified for the            │
+  │                                           connection.                        │
+  │ --schema,--schemaname               TEXT  Database schema to use. Overrides  │
+  │                                           the value specified for the        │
+  │                                           connection.                        │
+  │ --role,--rolename                   TEXT  Role to use. Overrides the value   │
+  │                                           specified for the connection.      │
+  │ --warehouse                         TEXT  Warehouse to use. Overrides the    │
+  │                                           value specified for the            │
+  │                                           connection.                        │
+  │ --temporary-connection      -x            Uses connection defined with       │
+  │                                           command line parameters, instead   │
+  │                                           of one defined in config           │
+  │ --mfa-passcode                      TEXT  Token to use for multi-factor      │
+  │                                           authentication (MFA)               │
+  ╰──────────────────────────────────────────────────────────────────────────────╯
+  ╭─ Global configuration ───────────────────────────────────────────────────────╮
+  │ --format           [TABLE|JSON]  Specifies the output format.                │
+  │                                  [default: TABLE]                            │
+  │ --verbose  -v                    Displays log entries for log levels `info`  │
+  │                                  and higher.                                 │
+  │ --debug                          Displays log entries for log levels `debug` │
+  │                                  and higher; debug logs contains additional  │
+  │                                  information.                                │
+  │ --silent                         Turns off intermediate output to console.   │
+  ╰──────────────────────────────────────────────────────────────────────────────╯
+  
+  
+  '''
+# ---
+# name: test_help_messages[spcs.service.unset]
+  '''
+                                                                                  
+   Usage: default spcs service unset [OPTIONS] NAME                               
+                                                                                  
+   Resets one or more properties or parameters for the service to their default   
+   value(s).                                                                      
+                                                                                  
+  ╭─ Arguments ──────────────────────────────────────────────────────────────────╮
+  │ *    name      TEXT  Name of the service. [default: None] [required]         │
+  ╰──────────────────────────────────────────────────────────────────────────────╯
+  ╭─ Options ────────────────────────────────────────────────────────────────────╮
+  │ --min-instances              Reset the MIN_INSTANCES property - Minimum      │
+  │                              number of service instances to run.             │
+  │ --max-instances              Reset the MAX_INSTANCES property - Maximum      │
+  │                              number of service instances to run.             │
+  │ --query-warehouse            Reset the QUERY_WAREHOUSE property - Warehouse  │
+  │                              to use if a service container connects to       │
+  │                              Snowflake to execute a query without explicitly │
+  │                              specifying a warehouse to use.                  │
+  │ --auto-resume                Reset the AUTO_RESUME property - The service    │
+  │                              will automatically resume when a service        │
+  │                              function or ingress is called.                  │
+  │ --comment                    Reset the COMMENT property - Comment for the    │
+  │                              service.                                        │
+  │ --help             -h        Show this message and exit.                     │
   ╰──────────────────────────────────────────────────────────────────────────────╯
   ╭─ Connection configuration ───────────────────────────────────────────────────╮
   │ --connection,--environment  -c      TEXT  Name of the connection, as defined │
@@ -3515,9 +3691,12 @@
   │ logs            Retrieves local logs from a Snowpark Container Services      │
   │                 service container.                                           │
   │ resume          Resumes the service from SUSPENDED state.                    │
+  │ set             Sets one or more properties or parameters for the service.   │
   │ status          Retrieves status of a Snowpark Container Services service.   │
   │ suspend         Suspends the service, shutting down and deleting all its     │
   │                 containers.                                                  │
+  │ unset           Resets one or more properties or parameters for the service  │
+  │                 to their default value(s).                                   │
   │ upgrade         Updates an existing service with a new specification file.   │
   ╰──────────────────────────────────────────────────────────────────────────────╯
   

--- a/tests/spcs/test_compute_pool.py
+++ b/tests/spcs/test_compute_pool.py
@@ -406,3 +406,12 @@ def test_unset_property_no_properties_cli(mock_unset, runner):
     mock_unset.assert_called_once_with(
         pool_name=pool_name, auto_resume=False, auto_suspend_secs=False, comment=False
     )
+
+
+def test_unset_property_with_args(runner):
+    pool_name = "test_pool"
+    result = runner.invoke(
+        ["spcs", "compute-pool", "unset", pool_name, "--auto-suspend-secs", "1"]
+    )
+    assert result.exit_code == 2, result.output
+    assert "Got unexpected extra argument" in result.output

--- a/tests/spcs/test_compute_pool.py
+++ b/tests/spcs/test_compute_pool.py
@@ -272,8 +272,12 @@ def test_set_property(mock_execute_query):
 
 def test_set_property_no_properties():
     pool_name = "test_pool"
-    with pytest.raises(NoPropertiesProvidedError):
+    with pytest.raises(NoPropertiesProvidedError) as e:
         ComputePoolManager().set_property(pool_name, None, None, None, None, None)
+    assert (
+        e.value.message
+        == f"No properties specified for compute pool '{pool_name}'. Please provide at least one property to set."
+    )
 
 
 @patch(
@@ -322,7 +326,9 @@ def test_set_property_cli(mock_set, mock_statement_success, runner):
 )
 def test_set_property_no_properties_cli(mock_set, runner):
     pool_name = "test_pool"
-    mock_set.side_effect = NoPropertiesProvidedError()
+    mock_set.side_effect = NoPropertiesProvidedError(
+        f"No properties specified for compute pool '{pool_name}'. Please provide at least one property to set."
+    )
     result = runner.invoke(["spcs", "compute-pool", "set", pool_name])
     assert result.exit_code == 1, result.output
     assert "No properties specified" in result.output
@@ -353,8 +359,12 @@ def test_unset_property(mock_execute_query):
 
 def test_unset_property_no_properties():
     pool_name = "test_pool"
-    with pytest.raises(NoPropertiesProvidedError):
+    with pytest.raises(NoPropertiesProvidedError) as e:
         ComputePoolManager().unset_property(pool_name, False, False, False)
+    assert (
+        e.value.message
+        == f"No properties specified for compute pool '{pool_name}'. Please provide at least one property to reset to its default value."
+    )
 
 
 @patch(
@@ -387,7 +397,9 @@ def test_unset_property_cli(mock_unset, mock_statement_success, runner):
 )
 def test_unset_property_no_properties_cli(mock_unset, runner):
     pool_name = "test_pool"
-    mock_unset.side_effect = NoPropertiesProvidedError()
+    mock_unset.side_effect = NoPropertiesProvidedError(
+        f"No properties specified for compute pool '{pool_name}'. Please provide at least one property to reset to its default value."
+    )
     result = runner.invoke(["spcs", "compute-pool", "unset", pool_name])
     assert result.exit_code == 1, result.output
     assert "No properties specified" in result.output

--- a/tests/spcs/test_services.py
+++ b/tests/spcs/test_services.py
@@ -416,8 +416,12 @@ def test_set_property(mock_execute_schema_query):
 
 def test_set_property_no_properties():
     service_name = "test_service"
-    with pytest.raises(NoPropertiesProvidedError):
+    with pytest.raises(NoPropertiesProvidedError) as e:
         ServiceManager().set_property(service_name, None, None, None, None, None)
+    assert (
+        e.value.message
+        == f"No properties specified for service '{service_name}'. Please provide at least one property to set."
+    )
 
 
 @patch("snowflake.cli.plugins.spcs.services.manager.ServiceManager.set_property")
@@ -462,7 +466,9 @@ def test_set_property_cli(mock_set, mock_statement_success, runner):
 @patch("snowflake.cli.plugins.spcs.services.manager.ServiceManager.set_property")
 def test_set_property_no_properties_cli(mock_set, runner):
     service_name = "test_service"
-    mock_set.side_effect = NoPropertiesProvidedError()
+    mock_set.side_effect = NoPropertiesProvidedError(
+        f"No properties specified for service '{service_name}'. Please provide at least one property to set."
+    )
     result = runner.invoke(["spcs", "service", "set", service_name])
     assert result.exit_code == 1, result.output
     assert "No properties specified" in result.output
@@ -491,8 +497,12 @@ def test_unset_property(mock_execute_query):
 
 def test_unset_property_no_properties():
     service_name = "test_service"
-    with pytest.raises(NoPropertiesProvidedError):
+    with pytest.raises(NoPropertiesProvidedError) as e:
         ServiceManager().unset_property(service_name, False, False, False, False, False)
+    assert (
+        e.value.message
+        == f"No properties specified for service '{service_name}'. Please provide at least one property to reset to its default value."
+    )
 
 
 @patch("snowflake.cli.plugins.spcs.services.manager.ServiceManager.unset_property")
@@ -528,7 +538,9 @@ def test_unset_property_cli(mock_unset, mock_statement_success, runner):
 @patch("snowflake.cli.plugins.spcs.services.manager.ServiceManager.unset_property")
 def test_unset_property_no_properties_cli(mock_unset, runner):
     service_name = "test_service"
-    mock_unset.side_effect = NoPropertiesProvidedError()
+    mock_unset.side_effect = NoPropertiesProvidedError(
+        f"No properties specified for service '{service_name}'. Please provide at least one property to reset to its default value."
+    )
     result = runner.invoke(["spcs", "service", "unset", service_name])
     assert result.exit_code == 1, result.output
     assert "No properties specified" in result.output

--- a/tests/spcs/test_services.py
+++ b/tests/spcs/test_services.py
@@ -552,3 +552,12 @@ def test_unset_property_no_properties_cli(mock_unset, runner):
         auto_resume=False,
         comment=False,
     )
+
+
+def test_unset_property_with_args(runner):
+    service_name = "test_service"
+    result = runner.invoke(
+        ["spcs", "service", "unset", service_name, "--min-instances", "1"]
+    )
+    assert result.exit_code == 2, result.output
+    assert "Got unexpected extra argument" in result.output

--- a/tests_integration/spcs/test_services.py
+++ b/tests_integration/spcs/test_services.py
@@ -26,6 +26,7 @@ def test_services(_test_steps: Tuple[SnowparkServicesTestSteps, str]):
     test_steps.describe_should_return_service(service_name)
     test_steps.list_endpoints_should_show_endpoint(service_name)
     test_steps.upgrade_service_should_change_spec(service_name)
+    test_steps.set_unset_service_property(service_name)
     test_steps.drop_service(service_name)
     test_steps.list_should_not_return_service(service_name)
 

--- a/tests_integration/spcs/testing_utils/spcs_services_utils.py
+++ b/tests_integration/spcs/testing_utils/spcs_services_utils.py
@@ -92,7 +92,7 @@ class SnowparkServicesTestSteps:
                 service_name,
                 "--comment",
                 comment,
-                *self._database_schema_args()
+                *self._database_schema_args(),
             ]
         )
         assert_that_result_is_successful_and_executed_successfully(
@@ -108,7 +108,7 @@ class SnowparkServicesTestSteps:
                 "unset",
                 service_name,
                 "--comment",
-                *self._database_schema_args()
+                *self._database_schema_args(),
             ]
         )
         assert_that_result_is_successful_and_executed_successfully(

--- a/tests_integration/spcs/testing_utils/spcs_services_utils.py
+++ b/tests_integration/spcs/testing_utils/spcs_services_utils.py
@@ -82,6 +82,41 @@ class SnowparkServicesTestSteps:
         assert result.json
         assert result.json[0]["name"] == service_name.upper()  # type: ignore
 
+    def set_unset_service_property(self, service_name: str) -> None:
+        comment = "test comment"
+        set_result = self._setup.runner.invoke_with_connection_json(
+            [
+                "spcs",
+                "service",
+                "set",
+                service_name,
+                "--comment",
+                comment,
+                *self._database_schema_args()
+            ]
+        )
+        assert_that_result_is_successful_and_executed_successfully(
+            set_result, is_json=True
+        )
+
+        description = self._execute_describe(service_name)
+        assert contains_row_with(description.json, {"comment": comment})
+        unset_result = self._setup.runner.invoke_with_connection_json(
+            [
+                "spcs",
+                "service",
+                "unset",
+                service_name,
+                "--comment",
+                *self._database_schema_args()
+            ]
+        )
+        assert_that_result_is_successful_and_executed_successfully(
+            unset_result, is_json=True
+        )
+        description = self._execute_describe(service_name)
+        assert contains_row_with(description.json, {"comment": None})
+
     def drop_service(self, service_name: str) -> None:
         result = self._setup.runner.invoke_with_connection_json(
             [


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [x] I've added or updated integration tests to verify correctness of my new code.
   * [ ] I've confirmed that my changes are working by executing CLI's commands manually.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [x] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
Added commands for spcs compute-pool set --<property1> <value1> ... and spcs compute-pool unset <name> --<property1>  .... These commands allow you to set values or reset to default values for properties of an existing compute pool, equivalent to ALTER COMPUTE POOL <name> SET/UNSET .... Added unit and integration tests for these commands.
