### PR TITLE
Raise error when default configs have too wide permissions

### DIFF
--- a/src/snowflake/cli/api/config.py
+++ b/src/snowflake/cli/api/config.py
@@ -50,7 +50,7 @@ def config_init(config_file: Optional[Path]):
     if config_file:
         CONFIG_MANAGER.file_path = config_file
     else:
-        _check_config_files_permissions()
+        _check_default_config_files_permissions()
     if not CONFIG_MANAGER.file_path.exists():
         _initialise_config(CONFIG_MANAGER.file_path)
     CONFIG_MANAGER.read_config()
@@ -194,7 +194,7 @@ def _dump_config(conf_file_cache: Dict):
         dump(conf_file_cache, fh)
 
 
-def _check_config_files_permissions() -> None:
+def _check_default_config_files_permissions() -> None:
     if CONNECTIONS_FILE.exists() and not file_permissions_are_strict(CONNECTIONS_FILE):
         raise ConfigFileTooWidePermissionsError(CONNECTIONS_FILE)
     if CONFIG_FILE.exists() and not file_permissions_are_strict(CONFIG_FILE):

--- a/src/snowflake/cli/api/config.py
+++ b/src/snowflake/cli/api/config.py
@@ -7,10 +7,13 @@ from typing import Any, Dict, Optional, Union
 
 import tomlkit
 from snowflake.cli.api.exceptions import (
+    ConfigFileTooWidePermissionsError,
     MissingConfiguration,
     UnsupportedConfigSectionTypeError,
 )
+from snowflake.cli.api.secure_utils import file_permissions_are_strict
 from snowflake.connector.config_manager import CONFIG_MANAGER
+from snowflake.connector.constants import CONFIG_FILE, CONNECTIONS_FILE
 from snowflake.connector.errors import MissingConfigOptionError
 from tomlkit import TOMLDocument, dump
 from tomlkit.container import Container
@@ -32,7 +35,6 @@ PLUGINS_SECTION = "plugins"
 LOGS_SECTION_PATH = [CLI_SECTION, LOGS_SECTION]
 PLUGINS_SECTION_PATH = [CLI_SECTION, PLUGINS_SECTION]
 
-
 CONFIG_MANAGER.add_option(
     name=CLI_SECTION,
     parse_str=tomlkit.parse,
@@ -47,6 +49,8 @@ def config_init(config_file: Optional[Path]):
     """
     if config_file:
         CONFIG_MANAGER.file_path = config_file
+    else:
+        _check_config_files_permissions()
     if not CONFIG_MANAGER.file_path.exists():
         _initialise_config(CONFIG_MANAGER.file_path)
     CONFIG_MANAGER.read_config()
@@ -188,3 +192,10 @@ def _get_envs_for_path(*path) -> dict:
 def _dump_config(conf_file_cache: Dict):
     with open(CONFIG_MANAGER.file_path, "w+") as fh:
         dump(conf_file_cache, fh)
+
+
+def _check_config_files_permissions() -> None:
+    if CONNECTIONS_FILE.exists() and not file_permissions_are_strict(CONNECTIONS_FILE):
+        raise ConfigFileTooWidePermissionsError(CONNECTIONS_FILE)
+    if CONFIG_FILE.exists() and not file_permissions_are_strict(CONFIG_FILE):
+        raise ConfigFileTooWidePermissionsError(CONFIG_FILE)

--- a/src/snowflake/cli/api/exceptions.py
+++ b/src/snowflake/cli/api/exceptions.py
@@ -107,3 +107,10 @@ class FileTooLargeError(ClickException):
 class DirectoryIsNotEmptyError(ClickException):
     def __init__(self, path: Path):
         super().__init__(f"Directory '{path}' is not empty")
+
+
+class ConfigFileTooWidePermissionsError(ClickException):
+    def __init__(self, path: Path):
+        super().__init__(
+            f'Configuration file {path} has too wide permissions, run `chmod 0600 "{path}"`'
+        )

--- a/src/snowflake/cli/api/secure_utils.py
+++ b/src/snowflake/cli/api/secure_utils.py
@@ -1,0 +1,15 @@
+import stat
+from pathlib import Path
+
+
+def file_permissions_are_strict(file_path: Path) -> bool:
+    accessible_by_others = (
+        # https://docs.python.org/3/library/stat.html
+        stat.S_IRGRP  # readable by group
+        | stat.S_IROTH  # readable by others
+        | stat.S_IWGRP  # writeable by group
+        | stat.S_IWOTH  # writeable by others
+        | stat.S_IXGRP  # executable by group
+        | stat.S_IXOTH  # executable by group
+    )
+    return (file_path.stat().st_mode & accessible_by_others) == 0

--- a/src/snowflake/cli/api/secure_utils.py
+++ b/src/snowflake/cli/api/secure_utils.py
@@ -10,6 +10,6 @@ def file_permissions_are_strict(file_path: Path) -> bool:
         | stat.S_IWGRP  # writeable by group
         | stat.S_IWOTH  # writeable by others
         | stat.S_IXGRP  # executable by group
-        | stat.S_IXOTH  # executable by group
+        | stat.S_IXOTH  # executable by others
     )
     return (file_path.stat().st_mode & accessible_by_others) == 0

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -190,22 +190,76 @@ def test_connections_toml_override_config_toml(test_snowcli_config, snowflake_ho
     }
 
 
-def test_too_wide_permissions_on_config_file(snowflake_home: Path):
+@pytest.mark.parametrize(
+    "chmod",
+    [
+        0o777,
+        0o770,
+        0o744,
+        0o740,
+        0o704,
+        0o722,
+        0o720,
+        0o702,
+        0o711,
+        0o710,
+        0o701,
+        0o677,
+        0o670,
+        0o644,
+        0o640,
+        0o604,
+        0o622,
+        0o620,
+        0o602,
+        0o611,
+        0o610,
+        0o601,
+    ],
+)
+def test_too_wide_permissions_on_config_file(snowflake_home: Path, chmod):
     config_path = snowflake_home / "config.toml"
     config_path.touch()
-    config_path.chmod(0o777)
+    config_path.chmod(chmod)
 
     with pytest.raises(ConfigFileTooWidePermissionsError) as error:
         config_init(None)
     assert error.value.message.__contains__("config.toml")
 
 
-def test_too_wide_permissions_on_connections_file(snowflake_home: Path):
+@pytest.mark.parametrize(
+    "chmod",
+    [
+        0o777,
+        0o770,
+        0o744,
+        0o740,
+        0o704,
+        0o722,
+        0o720,
+        0o702,
+        0o711,
+        0o710,
+        0o701,
+        0o677,
+        0o670,
+        0o644,
+        0o640,
+        0o604,
+        0o622,
+        0o620,
+        0o602,
+        0o611,
+        0o610,
+        0o601,
+    ],
+)
+def test_too_wide_permissions_on_connections_file(snowflake_home: Path, chmod):
     config_path = snowflake_home / "config.toml"
     config_path.touch()
     connections_path = snowflake_home / "connections.toml"
     connections_path.touch()
-    connections_path.chmod(0o777)
+    connections_path.chmod(chmod)
 
     with pytest.raises(ConfigFileTooWidePermissionsError) as error:
         config_init(None)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -141,3 +141,21 @@ def test_if_there_are_no_option_duplicates(runner):
     _check(ctx.command)
 
     assert duplicates == {}, "\n".join(duplicates)
+
+
+def test_fail_command_when_default_config_has_too_wide_permissions(
+    snowflake_home: Path,
+):
+    from snowflake.cli.app.cli_app import app
+
+    runner = CliRunner()
+
+    config_path = snowflake_home / "config.toml"
+    config_path.touch()
+    config_path.chmod(0o777)
+
+    result = runner.invoke(app, ["sql", "-q", "select 1"])
+
+    assert result.exit_code == 1, result.output
+    assert result.output.__contains__("Error")
+    assert result.output.__contains__("Configuration file")

--- a/tests/test_sql.py
+++ b/tests/test_sql.py
@@ -168,22 +168,3 @@ def test_show_specific_object_sql_execution_error(mock_execute):
     mock_execute.assert_called_once_with(
         r"show objects like 'EXAMPLE\\_ID'", cursor_class=DictCursor
     )
-
-
-def test_fail_command_when_default_config_has_too_wide_permissions(
-    snowflake_home: Path,
-):
-    from snowflake.cli.app.cli_app import app
-
-    runner = CliRunner()
-
-    config_path = snowflake_home / "config.toml"
-    config_path.touch()
-    config_path.chmod(0o777)
-
-    result = runner.invoke(app, ["sql", "-q", "select 1"], catch_exceptions=False)
-
-    assert result.exit_code == 1, result.output
-    assert result.output.strip().__contains__(
-        "conf │\n│ ig.toml has too wide permissions"
-    )

--- a/tests/testing_utils/files_and_dirs.py
+++ b/tests/testing_utils/files_and_dirs.py
@@ -6,6 +6,8 @@ from typing import Dict, Generator, List, Union
 
 import stat
 
+from snowflake.cli.api.secure_utils import file_permissions_are_strict
+
 
 def create_temp_file(suffix: str, dir: str, contents: List[str]) -> str:
     with tempfile.NamedTemporaryFile(suffix=suffix, dir=dir, delete=False) as tmp:
@@ -26,16 +28,7 @@ def _write_to_file(path: str, contents: List[str]) -> None:
 
 
 def assert_file_permissions_are_strict(file_path: Path) -> None:
-    ACCESSIBLE_BY_OTHERS = (
-        # https://docs.python.org/3/library/stat.html
-        stat.S_IRGRP  # readable by group
-        | stat.S_IROTH  # readable by others
-        | stat.S_IWGRP  # writeable by group
-        | stat.S_IWOTH  # writeable by others
-        | stat.S_IXGRP  # executable by group
-        | stat.S_IXOTH  # executable by group
-    )
-    assert (file_path.stat().st_mode & ACCESSIBLE_BY_OTHERS) == 0
+    assert file_permissions_are_strict(file_path)
 
 
 @contextmanager


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [ ] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
Raising error when default configs (config.toml or connections.toml) have too wide permissions. Error will not be raised if some other config is passed even if defaults have too wide permissions.
