### PR TITLE
SNOW-1057620: Enforce that get-repository-url is called with a connection database and schema

### DIFF
--- a/src/snowflake/cli/api/exceptions.py
+++ b/src/snowflake/cli/api/exceptions.py
@@ -114,3 +114,25 @@ class ConfigFileTooWidePermissionsError(ClickException):
         super().__init__(
             f'Configuration file {path} has too wide permissions, run `chmod 0600 "{path}"`'
         )
+
+
+class DatabaseNotProvidedError(ClickException):
+    def __init__(self):
+        super().__init__(
+            """
+            Database not specified. Please update connection to add `DATABASE` parameter,
+            or re-run command using `--dbname` option.
+            Use `snow connection list` to list existing connections
+            """
+        )
+
+
+class SchemaNotProvidedError(ClickException):
+    def __init__(self):
+        super().__init__(
+            """
+            Schema not specified. Please update connection to add `SCHEMA` parameter,
+            or re-run command using `--schema` option.
+            Use `snow connection list` to list existing connections
+            """
+        )

--- a/src/snowflake/cli/api/exceptions.py
+++ b/src/snowflake/cli/api/exceptions.py
@@ -119,12 +119,12 @@ class ConfigFileTooWidePermissionsError(ClickException):
 class DatabaseNotProvidedError(ClickException):
     def __init__(self):
         super().__init__(
-            "Database not specified. Please update connection to add `DATABASE` parameter, or re-run command using `--database` option. Use `snow connection list` to list existing connections."
+            "Database not specified. Please update connection to add `database` parameter, or re-run command using `--database` option. Use `snow connection list` to list existing connections."
         )
 
 
 class SchemaNotProvidedError(ClickException):
     def __init__(self):
         super().__init__(
-            "Schema not specified. Please update connection to add `SCHEMA` parameter, or re-run command using `--schema` option. Use `snow connection list` to list existing connections."
+            "Schema not specified. Please update connection to add `schema` parameter, or re-run command using `--schema` option. Use `snow connection list` to list existing connections."
         )

--- a/src/snowflake/cli/api/exceptions.py
+++ b/src/snowflake/cli/api/exceptions.py
@@ -119,20 +119,12 @@ class ConfigFileTooWidePermissionsError(ClickException):
 class DatabaseNotProvidedError(ClickException):
     def __init__(self):
         super().__init__(
-            """
-            Database not specified. Please update connection to add `DATABASE` parameter,
-            or re-run command using `--dbname` option.
-            Use `snow connection list` to list existing connections
-            """
+            "Database not specified. Please update connection to add `DATABASE` parameter, or re-run command using `--database` option. Use `snow connection list` to list existing connections."
         )
 
 
 class SchemaNotProvidedError(ClickException):
     def __init__(self):
         super().__init__(
-            """
-            Schema not specified. Please update connection to add `SCHEMA` parameter,
-            or re-run command using `--schema` option.
-            Use `snow connection list` to list existing connections
-            """
+            "Schema not specified. Please update connection to add `SCHEMA` parameter, or re-run command using `--schema` option. Use `snow connection list` to list existing connections."
         )

--- a/src/snowflake/cli/api/sql_execution.py
+++ b/src/snowflake/cli/api/sql_execution.py
@@ -145,12 +145,15 @@ class SqlExecutionMixin:
         unqualified_name: str,
         name_col: str = "name",
         in_clause: str = "",
+        check_schema: bool = False,
     ) -> Optional[dict]:
         """
         Executes a "show <objects> like" query for a particular entity with a
         given (unqualified) name. This command is useful when the corresponding
         "describe <object>" query does not provide the information you seek.
         """
+        if check_schema:
+            self.check_database_and_schema()
         show_obj_query = f"show {object_type_plural} like {identifier_to_show_like_pattern(unqualified_name)} {in_clause}".strip()
         show_obj_cursor = self._execute_query(  # type: ignore
             show_obj_query, cursor_class=DictCursor

--- a/src/snowflake/cli/plugins/spcs/image_repository/manager.py
+++ b/src/snowflake/cli/plugins/spcs/image_repository/manager.py
@@ -25,9 +25,10 @@ class ImageRepositoryManager(SqlExecutionMixin):
             raise ValueError(
                 f"repo_name '{repo_name}' is not a valid unquoted Snowflake identifier"
             )
-        # we explicitly do not allow this command to be called without a database and schema set
-        self.check_database_and_schema()
-        repo_row = self.show_specific_object("image repositories", repo_name)
+        # we explicitly do not allow this function to be used without connection database and schema set
+        repo_row = self.show_specific_object(
+            "image repositories", repo_name, check_schema=True
+        )
         if repo_row is None:
             raise ClickException(
                 f"Image repository '{repo_name}' does not exist in database '{self.get_database()}' and schema '{self.get_schema()}' or not authorized."

--- a/src/snowflake/cli/plugins/spcs/image_repository/manager.py
+++ b/src/snowflake/cli/plugins/spcs/image_repository/manager.py
@@ -25,6 +25,8 @@ class ImageRepositoryManager(SqlExecutionMixin):
             raise ValueError(
                 f"repo_name '{repo_name}' is not a valid unquoted Snowflake identifier"
             )
+        # we explicitly do not allow this command to be called without a database and schema set
+        self.check_database_and_schema()
         repo_row = self.show_specific_object("image repositories", repo_name)
         if repo_row is None:
             raise ClickException(

--- a/tests/spcs/test_image_repository.py
+++ b/tests/spcs/test_image_repository.py
@@ -199,7 +199,9 @@ def test_get_repository_url(mock_get_row, mock_check_database_and_schema):
     expected_row = MOCK_ROWS_DICT[0]
     mock_get_row.return_value = expected_row
     result = ImageRepositoryManager().get_repository_url(repo_name="IMAGES")
-    mock_get_row.assert_called_once_with("image repositories", "IMAGES")
+    mock_get_row.assert_called_once_with(
+        "image repositories", "IMAGES", check_schema=True
+    )
     assert isinstance(expected_row, Dict)
     assert "repository_url" in expected_row
     assert result == f"https://{expected_row['repository_url']}"
@@ -217,7 +219,9 @@ def test_get_repository_url_no_scheme(mock_get_row, mock_check_database_and_sche
     result = ImageRepositoryManager().get_repository_url(
         repo_name="IMAGES", with_scheme=False
     )
-    mock_get_row.assert_called_once_with("image repositories", "IMAGES")
+    mock_get_row.assert_called_once_with(
+        "image repositories", "IMAGES", check_schema=True
+    )
     assert isinstance(expected_row, Dict)
     assert "repository_url" in expected_row
     assert result == expected_row["repository_url"]
@@ -244,7 +248,9 @@ def test_get_repository_url_no_repo_found(
         e.value.message
         == "Image repository 'IMAGES' does not exist in database 'DB' and schema 'SCHEMA' or not authorized."
     )
-    mock_get_row.assert_called_once_with("image repositories", "IMAGES")
+    mock_get_row.assert_called_once_with(
+        "image repositories", "IMAGES", check_schema=True
+    )
 
 
 @mock.patch(

--- a/tests/test_sql.py
+++ b/tests/test_sql.py
@@ -157,7 +157,7 @@ def test_show_specific_object_no_match(mock_execute, mock_cursor):
     mock_execute.assert_called_once_with(
         r"show objects like 'EXAMPLE\\_ID'", cursor_class=DictCursor
     )
-    assert result == None
+    assert result is None
 
 
 @mock.patch("snowflake.cli.plugins.sql.manager.SqlExecutionMixin._execute_query")

--- a/tests_integration/spcs/testing_utils/compute_pool_utils.py
+++ b/tests_integration/spcs/testing_utils/compute_pool_utils.py
@@ -113,7 +113,7 @@ class ComputePoolTestSteps:
         assert contains_row_with(description.json, {"comment": None})
 
     def wait_until_compute_pool_is_idle(self, compute_pool_name: str) -> None:
-        self._wait_until_compute_pool_reaches_state(compute_pool_name, "IDLE", 300)
+        self._wait_until_compute_pool_reaches_state(compute_pool_name, "IDLE", 900)
 
     def wait_until_compute_pool_is_suspended(self, compute_pool_name: str) -> None:
         self._wait_until_compute_pool_reaches_state(compute_pool_name, "SUSPENDED", 60)
@@ -131,7 +131,7 @@ class ComputePoolTestSteps:
             time.sleep(10)
         status = self._execute_describe(compute_pool_name)
 
-        error_message = f"Compute pool {compute_pool_name} didn't reach target state '{target_state}' in {max_duration} seconds. Current state is '{status.json['state']}'"
+        error_message = f"Compute pool {compute_pool_name} didn't reach target state '{target_state}' in {max_duration} seconds. Current state is '{status.json[0]['state']}'"
         pytest.fail(error_message)
 
     def _execute_describe(self, compute_pool_name: str):


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually.
   * [ ] I've confirmed that my changes are up-to-date with the target branch.
   * [ ] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
[BUGFIX]
For schema level objects (image_repository, service) the connection database and schema must be specified otherwise unqualified names may be ambiguous about what object they refer to*. `get_repository_url` did not do this because it uses the show_specific_object function which does not check that connection database and schema are valid. This means that show_specific_object could potentially find multiple rows for the same repository name.

I have added an option to show_specific_object to check that database and schema are set when we are looking for schema level objects and updated corresponding unit tests. I have also done some cleanup on check_database_and_schema.

\* Otherwise there could be two objects with the same name **o** in different schemas. Operating on object **o** without a database and schema specified would be ambiguous.


**Example Usage (unchanged)**:
<img width="1052" alt="image" src="https://github.com/Snowflake-Labs/snowflake-cli/assets/156019931/858aaa42-3ba4-40be-b8a6-cb9b429e7324">

**Example Errors**:
<img width="1522" alt="image" src="https://github.com/Snowflake-Labs/snowflake-cli/assets/156019931/0d5e973f-4d75-4724-b8e2-48e4530c0dc9">
