### PR TITLE
SNOW-1054145-improve-cli-console-output-readability: use system colors for printed messaged

### DIFF
--- a/src/snowflake/cli/api/console/console.py
+++ b/src/snowflake/cli/api/console/console.py
@@ -8,10 +8,10 @@ from rich.text import Text
 from snowflake.cli.api.console.abc import AbstractConsole
 from snowflake.cli.api.console.enum import Output
 
-PHASE_STYLE: Style = Style(color="grey93", bold=True)
-STEP_STYLE: Style = Style(color="grey89", italic=True)
-INFO_STYLE: Style = Style(color="black")
-IMPORTANT_STYLE: Style = Style(color="red", bold=True, italic=True)
+PHASE_STYLE: Style = Style(bold=True)
+STEP_STYLE: Style = Style(italic=True)
+INFO_STYLE: Style = Style()
+IMPORTANT_STYLE: Style = Style(bold=True, italic=True)
 INDENTATION_LEVEL: int = 2
 
 


### PR DESCRIPTION
# SNOW-1054145

### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [ ] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [ ] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
Styles used for formatting CliConsole text use system colours.

## Dark background  
### before
<img width="1292" alt="dark_bg_before" src="https://github.com/Snowflake-Labs/snowflake-cli/assets/152898938/cd5392fd-39ac-4509-8cac-929164b07120">

### after
<img width="1318" alt="dark_bg_after" src="https://github.com/Snowflake-Labs/snowflake-cli/assets/152898938/203c777c-32ab-4926-b11b-c2139a8bfb91">
 
## Light background
### before
<img width="1146" alt="light_bg_before" src="https://github.com/Snowflake-Labs/snowflake-cli/assets/152898938/30dc1766-9176-4114-8f3a-d116b67674a3">

### after
<img width="1156" alt="light_bg_after" src="https://github.com/Snowflake-Labs/snowflake-cli/assets/152898938/f1a84434-d088-463f-aefd-7d4eded8ed7d">


