### PR TITLE
SNOW-1055803: Adding compute-pool status command

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -12,7 +12,7 @@
   * Added `image-registry login` command to fetch authentication token and log in to image registry in one command.
   * Added `image-repository url <repo_name>` command to get the URL for specified image repository.
   * Added `create` command for `image-repository`.
-  * Added `set (property)`, `unset (property)`, `suspend` and `resume` commands for `compute-pool`.
+  * Added `status`, `set (property)`, `unset (property)`, `suspend` and `resume` commands for `compute-pool`.
   * Added `set (property)`, `unset (property)`,`upgrade` and `list-endpoints` commands for `service`.
 * Connections parameters are also supported by generic environment variables:
   * `SNOWFLAKE_ACCOUNT`

--- a/src/snowflake/cli/plugins/spcs/compute_pool/commands.py
+++ b/src/snowflake/cli/plugins/spcs/compute_pool/commands.py
@@ -183,3 +183,12 @@ def unset_property(
         comment=comment,
     )
     return SingleQueryResult(cursor)
+
+
+@app.command(requires_connection=True)
+def status(pool_name: str = ComputePoolNameArgument, **options) -> CommandResult:
+    """
+    Retrieves status of a compute pool along with a relevant message, if one exists.
+    """
+    cursor = ComputePoolManager().status(pool_name=pool_name)
+    return SingleQueryResult(cursor)

--- a/src/snowflake/cli/plugins/spcs/compute_pool/manager.py
+++ b/src/snowflake/cli/plugins/spcs/compute_pool/manager.py
@@ -94,3 +94,8 @@ class ComputePoolManager(SqlExecutionMixin):
         unset_list = [property_name for property_name, value in property_pairs if value]
         query = f"alter compute pool {pool_name} unset {','.join(unset_list)}"
         return self._execute_query(query)
+
+    def status(self, pool_name: str):
+        return self._execute_query(
+            f"call system$get_compute_pool_status('{pool_name}')"
+        )

--- a/tests/__snapshots__/test_help_messages.ambr
+++ b/tests/__snapshots__/test_help_messages.ambr
@@ -2058,6 +2058,70 @@
   
   '''
 # ---
+# name: test_help_messages[spcs.compute-pool.status]
+  '''
+                                                                                  
+   Usage: default spcs compute-pool status [OPTIONS] POOL_NAME                    
+                                                                                  
+   Retrieves status of a compute pool along with a relevant message, if one       
+   exists.                                                                        
+                                                                                  
+  ╭─ Arguments ──────────────────────────────────────────────────────────────────╮
+  │ *    pool_name      TEXT  Name of the compute pool. [required]               │
+  ╰──────────────────────────────────────────────────────────────────────────────╯
+  ╭─ Options ────────────────────────────────────────────────────────────────────╮
+  │ --help  -h        Show this message and exit.                                │
+  ╰──────────────────────────────────────────────────────────────────────────────╯
+  ╭─ Connection configuration ───────────────────────────────────────────────────╮
+  │ --connection,--environment  -c      TEXT  Name of the connection, as defined │
+  │                                           in your `config.toml`. Default:    │
+  │                                           `default`.                         │
+  │ --account,--accountname             TEXT  Name assigned to your Snowflake    │
+  │                                           account. Overrides the value       │
+  │                                           specified for the connection.      │
+  │ --user,--username                   TEXT  Username to connect to Snowflake.  │
+  │                                           Overrides the value specified for  │
+  │                                           the connection.                    │
+  │ --password                          TEXT  Snowflake password. Overrides the  │
+  │                                           value specified for the            │
+  │                                           connection.                        │
+  │ --authenticator                     TEXT  Snowflake authenticator. Overrides │
+  │                                           the value specified for the        │
+  │                                           connection.                        │
+  │ --private-key-path                  TEXT  Snowflake private key path.        │
+  │                                           Overrides the value specified for  │
+  │                                           the connection.                    │
+  │ --database,--dbname                 TEXT  Database to use. Overrides the     │
+  │                                           value specified for the            │
+  │                                           connection.                        │
+  │ --schema,--schemaname               TEXT  Database schema to use. Overrides  │
+  │                                           the value specified for the        │
+  │                                           connection.                        │
+  │ --role,--rolename                   TEXT  Role to use. Overrides the value   │
+  │                                           specified for the connection.      │
+  │ --warehouse                         TEXT  Warehouse to use. Overrides the    │
+  │                                           value specified for the            │
+  │                                           connection.                        │
+  │ --temporary-connection      -x            Uses connection defined with       │
+  │                                           command line parameters, instead   │
+  │                                           of one defined in config           │
+  │ --mfa-passcode                      TEXT  Token to use for multi-factor      │
+  │                                           authentication (MFA)               │
+  ╰──────────────────────────────────────────────────────────────────────────────╯
+  ╭─ Global configuration ───────────────────────────────────────────────────────╮
+  │ --format           [TABLE|JSON]  Specifies the output format.                │
+  │                                  [default: TABLE]                            │
+  │ --verbose  -v                    Displays log entries for log levels `info`  │
+  │                                  and higher.                                 │
+  │ --debug                          Displays log entries for log levels `debug` │
+  │                                  and higher; debug logs contains additional  │
+  │                                  information.                                │
+  │ --silent                         Turns off intermediate output to console.   │
+  ╰──────────────────────────────────────────────────────────────────────────────╯
+  
+  
+  '''
+# ---
 # name: test_help_messages[spcs.compute-pool.stop-all]
   '''
                                                                                   
@@ -2276,6 +2340,8 @@
   │ create    Creates a compute pool with a specified number of nodes.           │
   │ resume    Resumes the compute pool from SUSPENDED state.                     │
   │ set       Sets one or more properties or parameters for the compute pool.    │
+  │ status    Retrieves status of a compute pool along with a relevant message,  │
+  │           if one exists.                                                     │
   │ stop-all  Deletes all services running on the compute pool.                  │
   │ suspend   Suspends the compute pool by suspending all currently running      │
   │           services and then releasing compute pool nodes.                    │

--- a/tests_integration/spcs/testing_utils/compute_pool_utils.py
+++ b/tests_integration/spcs/testing_utils/compute_pool_utils.py
@@ -40,13 +40,11 @@ class ComputePoolTestSteps:
                 "CPU_X64_XS",
             ]
         )
-        assert_that_result_is_successful_and_output_json_equals(
-            result,
-            [
-                {
-                    "status": f"Compute Pool {compute_pool_name.upper()} successfully created."
-                }
-            ],
+        assert result.json, result.output
+        assert "status" in result.json
+        assert (
+            f"Compute Pool {compute_pool_name.upper()} successfully created."
+            in result.json["status"]  # type: ignore
         )
 
     def list_should_return_compute_pool(self, compute_pool_name) -> None:

--- a/tests_integration/spcs/testing_utils/compute_pool_utils.py
+++ b/tests_integration/spcs/testing_utils/compute_pool_utils.py
@@ -8,6 +8,8 @@ from tests_integration.conftest import SnowCLIRunner
 from tests_integration.test_utils import contains_row_with, not_contains_row_with
 from tests_integration.testing_utils.assertions.test_result_assertions import (
     assert_that_result_is_successful_and_executed_successfully,
+    assert_that_result_is_successful_and_output_json_contains,
+    assert_that_result_is_successful_and_output_json_equals,
 )
 
 
@@ -38,16 +40,20 @@ class ComputePoolTestSteps:
                 "CPU_X64_XS",
             ]
         )
-        assert result.json, result.output
-        assert "status" in result.json
-        assert (
-            f"Compute Pool {compute_pool_name.upper()} successfully created."
-            in result.json["status"]  # type: ignore
+        assert_that_result_is_successful_and_output_json_equals(
+            result,
+            [
+                {
+                    "status": f"Compute Pool {compute_pool_name.upper()} successfully created."
+                }
+            ],
         )
 
     def list_should_return_compute_pool(self, compute_pool_name) -> None:
         result = self._execute_list()
-        assert contains_row_with(result.json, {"name": compute_pool_name.upper()})
+        assert_that_result_is_successful_and_output_json_contains(
+            result, {"name": compute_pool_name.upper()}
+        )
 
     def list_should_not_return_compute_pool(self, compute_pool_name: str) -> None:
         result = self._execute_list()
@@ -55,9 +61,19 @@ class ComputePoolTestSteps:
 
     def describe_should_return_compute_pool(self, compute_pool_name: str) -> None:
         result = self._execute_describe(compute_pool_name)
-        assert result.json
-        assert len(result.json) == 1
-        assert result.json[0]["name"] == compute_pool_name.upper()
+        assert_that_result_is_successful_and_output_json_contains(
+            result, {"name": compute_pool_name.upper()}
+        )
+
+    def status_should_return_compute_pool_idle_status(
+        self, compute_pool_name: str
+    ) -> None:
+        result = self._setup.runner.invoke_with_connection_json(
+            ["spcs", "compute-pool", "status", compute_pool_name]
+        )
+        assert_that_result_is_successful_and_output_json_contains(
+            result, {"status": "IDLE"}
+        )
 
     def drop_compute_pool(self, compute_pool_name: str) -> None:
         result = self._setup.runner.invoke_with_connection_json(
@@ -68,11 +84,9 @@ class ComputePoolTestSteps:
                 compute_pool_name,
             ],
         )
-        assert result.json
-        assert len(result.json) == 1
-        assert result.json[0] == {  # type: ignore
-            "status": f"{compute_pool_name.upper()} successfully dropped."
-        }
+        assert_that_result_is_successful_and_output_json_equals(
+            result, [{"status": f"{compute_pool_name.upper()} successfully dropped."}]
+        )
 
     def stop_all_on_compute_pool(self, compute_pool_name: str) -> None:
         result = self._setup.runner.invoke_with_connection_json(
@@ -101,16 +115,20 @@ class ComputePoolTestSteps:
             set_result, is_json=True
         )
 
-        description = self._execute_describe(compute_pool_name)
-        assert contains_row_with(description.json, {"comment": comment})
+        describe_result = self._execute_describe(compute_pool_name)
+        assert_that_result_is_successful_and_output_json_contains(
+            describe_result, {"comment": comment}
+        )
         unset_result = self._setup.runner.invoke_with_connection_json(
             ["spcs", "compute-pool", "unset", compute_pool_name, "--comment"]
         )
         assert_that_result_is_successful_and_executed_successfully(
             unset_result, is_json=True
         )
-        description = self._execute_describe(compute_pool_name)
-        assert contains_row_with(description.json, {"comment": None})
+        describe_result = self._execute_describe(compute_pool_name)
+        assert_that_result_is_successful_and_output_json_contains(
+            describe_result, {"comment": None}
+        )
 
     def wait_until_compute_pool_is_idle(self, compute_pool_name: str) -> None:
         self._wait_until_compute_pool_reaches_state(compute_pool_name, "IDLE", 900)


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [x] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [x] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
Added a new command `spcs compute-pool status` to retrieve the current status of a compute pool along with a relevant message, if any. This is helpful for debugging and observability. Updated unit and integration tests to include this new command.


**Usage:**
![image](https://github.com/Snowflake-Labs/snowflake-cli/assets/156019931/7a08eefe-503a-476e-b644-59b87b4f246b)
