### PR TITLE
SNOW-1057322: Adding support for qualified names for services.

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,3 +1,13 @@
+# v2.2.0
+
+## Backward incompatibility
+
+## New additions
+
+## Fixes and improvements
+* Added validation that service, compute pool, and image repository names are unqualified identifiers.
+* `spcs service` commands now accept qualified names.
+
 # v2.1.0
 
 ## Backward incompatibility
@@ -36,9 +46,6 @@
 * Restricted permissions of automatically created files
 * Fixed bug where `spcs service create` would not throw error if service with specified name already exists.
 * Logging into the file by default (INFO level)
-* Added validation that service, compute pool, and image repository names are unqualified identifiers.
-* `spcs service` commands now accept qualified names.
-
 
 # v2.0.0
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -36,6 +36,8 @@
 * Restricted permissions of automatically created files
 * Fixed bug where `spcs service create` would not throw error if service with specified name already exists.
 * Logging into the file by default (INFO level)
+* Added validation that service, compute pool, and image repository names are unqualified identifiers.
+* `spcs service` commands now accept qualified names.
 
 
 # v2.0.0

--- a/src/snowflake/cli/api/project/util.py
+++ b/src/snowflake/cli/api/project/util.py
@@ -48,7 +48,7 @@ def is_valid_identifier(identifier: str) -> bool:
     )
 
 
-def is_valid_object_name(name: str, max_depth=2) -> bool:
+def is_valid_object_name(name: str, max_depth=2, allow_quoted=True) -> bool:
     """
     Determines whether the given identifier is a valid object name in the form <name>, <schema>.<name>, or <database>.<schema>.<name>.
     Max_depth determines how many valid identifiers are allowed. For example, account level objects would have a max depth of 0
@@ -56,9 +56,10 @@ def is_valid_object_name(name: str, max_depth=2) -> bool:
     """
     if max_depth < 0:
         raise ValueError("max_depth must be non-negative")
-    pattern = (
-        rf"{VALID_IDENTIFIER_REGEX}(?:\.{VALID_IDENTIFIER_REGEX}){{0,{max_depth}}}"
+    identifier_pattern = (
+        VALID_IDENTIFIER_REGEX if allow_quoted else UNQUOTED_IDENTIFIER_REGEX
     )
+    pattern = rf"{identifier_pattern}(?:\.{identifier_pattern}){{0,{max_depth}}}"
     return re.fullmatch(pattern, name) is not None
 
 

--- a/src/snowflake/cli/plugins/spcs/compute_pool/commands.py
+++ b/src/snowflake/cli/plugins/spcs/compute_pool/commands.py
@@ -24,7 +24,7 @@ def _compute_pool_name_callback(name: str) -> str:
     """
     Verifies that compute pool name is a single valid identifier.
     """
-    if not is_valid_object_name(name, 0):
+    if not is_valid_object_name(name, max_depth=0, allow_quoted=False):
         raise ClickException(f"'{name}' is not a valid compute pool name.")
     return name
 

--- a/src/snowflake/cli/plugins/spcs/compute_pool/commands.py
+++ b/src/snowflake/cli/plugins/spcs/compute_pool/commands.py
@@ -25,7 +25,9 @@ def _compute_pool_name_callback(name: str) -> str:
     Verifies that compute pool name is a single valid identifier.
     """
     if not is_valid_object_name(name, max_depth=0, allow_quoted=False):
-        raise ClickException(f"'{name}' is not a valid compute pool name.")
+        raise ClickException(
+            f"'{name}' is not a valid compute pool name. Note that compute pool names must be unquoted identifiers."
+        )
     return name
 
 

--- a/src/snowflake/cli/plugins/spcs/image_repository/commands.py
+++ b/src/snowflake/cli/plugins/spcs/image_repository/commands.py
@@ -22,7 +22,9 @@ app = SnowTyper(
 
 def _repo_name_callback(name: str):
     if not is_valid_object_name(name, max_depth=0, allow_quoted=True):
-        raise ClickException(f"'{name}' is not a valid image repository name.")
+        raise ClickException(
+            f"'{name}' is not a valid image repository name. Note that image repository names must be unquoted identifiers. The same constraint also applies to database and schema names where you create an image repository."
+        )
     return name
 
 

--- a/src/snowflake/cli/plugins/spcs/image_repository/commands.py
+++ b/src/snowflake/cli/plugins/spcs/image_repository/commands.py
@@ -10,7 +10,7 @@ from snowflake.cli.api.output.types import (
     MessageResult,
     SingleQueryResult,
 )
-from snowflake.cli.api.project.util import is_valid_unquoted_identifier
+from snowflake.cli.api.project.util import is_valid_object_name
 from snowflake.cli.plugins.spcs.image_registry.manager import RegistryManager
 from snowflake.cli.plugins.spcs.image_repository.manager import ImageRepositoryManager
 
@@ -21,10 +21,8 @@ app = SnowTyper(
 
 
 def _repo_name_callback(name: str):
-    if not is_valid_unquoted_identifier(name):
-        raise ClickException(
-            "Repository name must be a valid unquoted identifier. Quoted names for special characters or case-sensitive names are not supported for image repositories."
-        )
+    if not is_valid_object_name(name, max_depth=0, allow_quoted=True):
+        raise ClickException(f"'{name}' is not a valid image repository name.")
     return name
 
 

--- a/src/snowflake/cli/plugins/spcs/services/commands.py
+++ b/src/snowflake/cli/plugins/spcs/services/commands.py
@@ -29,7 +29,7 @@ app = SnowTyper(
 
 
 def _service_name_callback(name: str) -> str:
-    if not is_valid_object_name(name, 2):
+    if not is_valid_object_name(name, max_depth=0, allow_quoted=False):
         raise ClickException(f"'{name}' is not a valid service name.")
     return name
 

--- a/src/snowflake/cli/plugins/spcs/services/commands.py
+++ b/src/snowflake/cli/plugins/spcs/services/commands.py
@@ -29,7 +29,7 @@ app = SnowTyper(
 
 
 def _service_name_callback(name: str) -> str:
-    if not is_valid_object_name(name, max_depth=0, allow_quoted=False):
+    if not is_valid_object_name(name, max_depth=2, allow_quoted=False):
         raise ClickException(
             f"'{name}' is not a valid service name. Note service names must be unquoted identifiers. The same constraint also applies to database and schema names where you create a service."
         )

--- a/src/snowflake/cli/plugins/spcs/services/commands.py
+++ b/src/snowflake/cli/plugins/spcs/services/commands.py
@@ -30,7 +30,9 @@ app = SnowTyper(
 
 def _service_name_callback(name: str) -> str:
     if not is_valid_object_name(name, max_depth=0, allow_quoted=False):
-        raise ClickException(f"'{name}' is not a valid service name.")
+        raise ClickException(
+            f"'{name}' is not a valid service name. Note service names must be unquoted identifiers. The same constraint also applies to database and schema names where you create a service."
+        )
     return name
 
 

--- a/src/snowflake/cli/plugins/spcs/services/manager.py
+++ b/src/snowflake/cli/plugins/spcs/services/manager.py
@@ -60,7 +60,7 @@ class ServiceManager(SqlExecutionMixin):
             query.append(f"WITH TAG ({tag_list})")
 
         try:
-            return self._execute_schema_query(strip_empty_lines(query))
+            return self._execute_query(strip_empty_lines(query))
         except ProgrammingError as e:
             handle_object_already_exists(e, ObjectType.SERVICE, service_name)
 
@@ -75,30 +75,28 @@ class ServiceManager(SqlExecutionMixin):
         return json.dumps(data)
 
     def status(self, service_name: str) -> SnowflakeCursor:
-        return self._execute_schema_query(
-            f"CALL SYSTEM$GET_SERVICE_STATUS('{service_name}')"
-        )
+        return self._execute_query(f"CALL SYSTEM$GET_SERVICE_STATUS('{service_name}')")
 
     def logs(
         self, service_name: str, instance_id: str, container_name: str, num_lines: int
     ):
-        return self._execute_schema_query(
+        return self._execute_query(
             f"call SYSTEM$GET_SERVICE_LOGS('{service_name}', '{instance_id}', '{container_name}', {num_lines});"
         )
 
     def upgrade_spec(self, service_name: str, spec_path: Path):
         spec = self._read_yaml(spec_path)
         query = f"alter service {service_name} from specification $$ {spec} $$"
-        return self._execute_schema_query(query)
+        return self._execute_query(query)
 
     def list_endpoints(self, service_name: str) -> SnowflakeCursor:
-        return self._execute_schema_query(f"show endpoints in service {service_name}")
+        return self._execute_query(f"show endpoints in service {service_name}")
 
     def suspend(self, service_name: str):
-        return self._execute_schema_query(f"alter service {service_name} suspend")
+        return self._execute_query(f"alter service {service_name} suspend")
 
     def resume(self, service_name: str):
-        return self._execute_schema_query(f"alter service {service_name} resume")
+        return self._execute_query(f"alter service {service_name} resume")
 
     def set_property(
         self,
@@ -126,7 +124,7 @@ class ServiceManager(SqlExecutionMixin):
         for property_name, value in property_pairs:
             if value is not None:
                 query.append(f"{property_name} = {value}")
-        return self._execute_schema_query(strip_empty_lines(query))
+        return self._execute_query(strip_empty_lines(query))
 
     def unset_property(
         self,
@@ -152,4 +150,4 @@ class ServiceManager(SqlExecutionMixin):
             )
         unset_list = [property_name for property_name, value in property_pairs if value]
         query = f"alter service {service_name} unset {','.join(unset_list)}"
-        return self._execute_schema_query(query)
+        return self._execute_query(query)

--- a/tests/project/test_util.py
+++ b/tests/project/test_util.py
@@ -117,6 +117,20 @@ def test_is_valid_object_name():
                     assert not is_valid_object_name(name)
 
 
+def test_is_valid_object_name_disallow_quoted():
+    valid_identifiers = VALID_QUOTED_IDENTIFIERS + VALID_UNQUOTED_IDENTIFIERS
+    for num in [1, 2, 3]:
+        name_tuples = list(permutations(valid_identifiers, num))
+        for name_tuple in name_tuples:
+            has_quotes = any(t in VALID_QUOTED_IDENTIFIERS for t in name_tuple)
+            name = ".".join(name_tuple)
+            assert is_valid_object_name(name, max_depth=2, allow_quoted=True)
+            if has_quotes:
+                assert not is_valid_object_name(name, max_depth=2, allow_quoted=False)
+            else:
+                assert is_valid_object_name(name, max_depth=2, allow_quoted=False)
+
+
 def test_to_identifier():
     for id in VALID_UNQUOTED_IDENTIFIERS:
         assert to_identifier(id) == id

--- a/tests/spcs/test_services.py
+++ b/tests/spcs/test_services.py
@@ -34,10 +34,8 @@ SPEC_DICT = {
 }
 
 
-@patch(
-    "snowflake.cli.plugins.spcs.services.manager.ServiceManager._execute_schema_query"
-)
-def test_create_service(mock_execute_schema_query, other_directory):
+@patch("snowflake.cli.plugins.spcs.services.manager.ServiceManager._execute_query")
+def test_create_service(mock_execute_query, other_directory):
     service_name = "test_service"
     compute_pool = "test_pool"
     min_instances = 42
@@ -55,7 +53,7 @@ def test_create_service(mock_execute_schema_query, other_directory):
     comment = "'user\\'s comment'"
 
     cursor = Mock(spec=SnowflakeCursor)
-    mock_execute_schema_query.return_value = cursor
+    mock_execute_query.return_value = cursor
 
     result = ServiceManager().create(
         service_name=service_name,
@@ -82,7 +80,7 @@ def test_create_service(mock_execute_schema_query, other_directory):
             "WITH TAG (test_tag='test value',key='value')",
         ]
     )
-    actual_query = " ".join(mock_execute_schema_query.mock_calls[0].args[0].split())
+    actual_query = " ".join(mock_execute_query.mock_calls[0].args[0].split())
     assert expected_query == actual_query
     assert result == cursor
 
@@ -196,9 +194,7 @@ def test_create_service_with_invalid_spec(mock_read_yaml):
 
 
 @patch("snowflake.cli.plugins.spcs.services.manager.ServiceManager._read_yaml")
-@patch(
-    "snowflake.cli.plugins.spcs.services.manager.ServiceManager._execute_schema_query"
-)
+@patch("snowflake.cli.plugins.spcs.services.manager.ServiceManager._execute_query")
 @patch("snowflake.cli.plugins.spcs.services.manager.handle_object_already_exists")
 def test_create_repository_already_exists(mock_handle, mock_execute, mock_read_yaml):
     service_name = "test_object"
@@ -226,32 +222,28 @@ def test_create_repository_already_exists(mock_handle, mock_execute, mock_read_y
     )
 
 
-@patch(
-    "snowflake.cli.plugins.spcs.services.manager.ServiceManager._execute_schema_query"
-)
-def test_status(mock_execute_schema_query):
+@patch("snowflake.cli.plugins.spcs.services.manager.ServiceManager._execute_query")
+def test_status(mock_execute_query):
     service_name = "test_service"
     cursor = Mock(spec=SnowflakeCursor)
-    mock_execute_schema_query.return_value = cursor
+    mock_execute_query.return_value = cursor
     result = ServiceManager().status(service_name)
     expected_query = "CALL SYSTEM$GET_SERVICE_STATUS('test_service')"
-    mock_execute_schema_query.assert_called_once_with(expected_query)
+    mock_execute_query.assert_called_once_with(expected_query)
     assert result == cursor
 
 
-@patch(
-    "snowflake.cli.plugins.spcs.services.manager.ServiceManager._execute_schema_query"
-)
-def test_logs(mock_execute_schema_query):
+@patch("snowflake.cli.plugins.spcs.services.manager.ServiceManager._execute_query")
+def test_logs(mock_execute_query):
     service_name = "test_service"
     container_name = "test_container"
     cursor = Mock(spec=SnowflakeCursor)
-    mock_execute_schema_query.return_value = cursor
+    mock_execute_query.return_value = cursor
     result = ServiceManager().logs(service_name, "10", container_name, 42)
     expected_query = (
         "call SYSTEM$GET_SERVICE_LOGS('test_service', '10', 'test_container', 42);"
     )
-    mock_execute_schema_query.assert_called_once_with(expected_query)
+    mock_execute_query.assert_called_once_with(expected_query)
     assert result == cursor
 
 
@@ -263,13 +255,11 @@ def test_read_yaml(other_directory):
     assert result == json.dumps(SPEC_DICT)
 
 
-@patch(
-    "snowflake.cli.plugins.spcs.services.manager.ServiceManager._execute_schema_query"
-)
-def test_upgrade_spec(mock_execute_schema_query, other_directory):
+@patch("snowflake.cli.plugins.spcs.services.manager.ServiceManager._execute_query")
+def test_upgrade_spec(mock_execute_query, other_directory):
     service_name = "test_service"
     cursor = Mock(spec=SnowflakeCursor)
-    mock_execute_schema_query.return_value = cursor
+    mock_execute_query.return_value = cursor
     tmp_dir = Path(other_directory)
     spec_path = tmp_dir / "spec.yml"
     spec_path.write_text(SPEC_CONTENT)
@@ -277,7 +267,7 @@ def test_upgrade_spec(mock_execute_schema_query, other_directory):
     expected_query = (
         f"alter service {service_name} from specification $$ {json.dumps(SPEC_DICT)} $$"
     )
-    actual_query = " ".join(mock_execute_schema_query.mock_calls[0].args[0].split())
+    actual_query = " ".join(mock_execute_query.mock_calls[0].args[0].split())
     assert expected_query == actual_query
     assert result == cursor
 
@@ -302,16 +292,14 @@ def test_upgrade_spec_cli(mock_upgrade_spec, mock_cursor, runner, other_director
     assert "Statement executed successfully" in result.output
 
 
-@patch(
-    "snowflake.cli.plugins.spcs.services.manager.ServiceManager._execute_schema_query"
-)
-def test_list_endpoints(mock_execute_schema_query):
+@patch("snowflake.cli.plugins.spcs.services.manager.ServiceManager._execute_query")
+def test_list_endpoints(mock_execute_query):
     service_name = "test_service"
     cursor = Mock(spec=SnowflakeCursor)
-    mock_execute_schema_query.return_value = cursor
+    mock_execute_query.return_value = cursor
     result = ServiceManager().list_endpoints(service_name)
     expected_query = f"show endpoints in service test_service"
-    mock_execute_schema_query.assert_called_once_with(expected_query)
+    mock_execute_query.assert_called_once_with(expected_query)
     assert result == cursor
 
 
@@ -330,16 +318,14 @@ def test_list_endpoints_cli(mock_list_endpoints, mock_cursor, runner):
     assert "test-snowflakecomputing.app" in result.output
 
 
-@patch(
-    "snowflake.cli.plugins.spcs.services.manager.ServiceManager._execute_schema_query"
-)
-def test_suspend(mock_execute_schema_query):
+@patch("snowflake.cli.plugins.spcs.services.manager.ServiceManager._execute_query")
+def test_suspend(mock_execute_query):
     service_name = "test_service"
     cursor = Mock(spec=SnowflakeCursor)
-    mock_execute_schema_query.return_value = cursor
+    mock_execute_query.return_value = cursor
     result = ServiceManager().suspend(service_name)
     expected_query = f"alter service {service_name} suspend"
-    mock_execute_schema_query.assert_called_once_with(expected_query)
+    mock_execute_query.assert_called_once_with(expected_query)
     assert result == cursor
 
 
@@ -355,16 +341,14 @@ def test_suspend_cli(mock_suspend, mock_cursor, runner):
     assert "Statement executed successfully" in result.output
 
 
-@patch(
-    "snowflake.cli.plugins.spcs.services.manager.ServiceManager._execute_schema_query"
-)
-def test_resume(mock_execute_schema_query):
+@patch("snowflake.cli.plugins.spcs.services.manager.ServiceManager._execute_query")
+def test_resume(mock_execute_query):
     service_name = "test_service"
     cursor = Mock(spec=SnowflakeCursor)
-    mock_execute_schema_query.return_value = cursor
+    mock_execute_query.return_value = cursor
     result = ServiceManager().resume(service_name)
     expected_query = f"alter service {service_name} resume"
-    mock_execute_schema_query.assert_called_once_with(expected_query)
+    mock_execute_query.assert_called_once_with(expected_query)
     assert result == cursor
 
 
@@ -380,10 +364,8 @@ def test_resume_cli(mock_resume, mock_cursor, runner):
     assert "Statement executed successfully" in result.output
 
 
-@patch(
-    "snowflake.cli.plugins.spcs.services.manager.ServiceManager._execute_schema_query"
-)
-def test_set_property(mock_execute_schema_query):
+@patch("snowflake.cli.plugins.spcs.services.manager.ServiceManager._execute_query")
+def test_set_property(mock_execute_query):
     service_name = "test_service"
     min_instances = 2
     max_instances = 3
@@ -391,7 +373,7 @@ def test_set_property(mock_execute_schema_query):
     auto_resume = False
     comment = to_string_literal("this is a test")
     cursor = Mock(spec=SnowflakeCursor)
-    mock_execute_schema_query.return_value = cursor
+    mock_execute_query.return_value = cursor
     result = ServiceManager().set_property(
         service_name=service_name,
         min_instances=min_instances,
@@ -410,7 +392,7 @@ def test_set_property(mock_execute_schema_query):
             f"comment = {comment}",
         ]
     )
-    mock_execute_schema_query.assert_called_once_with(expected_query)
+    mock_execute_query.assert_called_once_with(expected_query)
     assert result == cursor
 
 
@@ -482,9 +464,7 @@ def test_set_property_no_properties_cli(mock_set, runner):
     )
 
 
-@patch(
-    "snowflake.cli.plugins.spcs.services.manager.ServiceManager._execute_schema_query"
-)
+@patch("snowflake.cli.plugins.spcs.services.manager.ServiceManager._execute_query")
 def test_unset_property(mock_execute_query):
     service_name = "test_service"
     cursor = Mock(spec=SnowflakeCursor)


### PR DESCRIPTION
### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [x] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
Changed implementation of service commands from using _execute_schema_query to _execute_query. If no database/schema is specified in the connection, the user will see an SQL execution error stating to use a database/schema or qualified name. This is consistent with the behavior of commands like `snow object describe` and `snow object drop`.

Also added validation that service, image repository, and compute pool names must be unquoted identifiers.

**Usage**:
<img width="1442" alt="unqualified-failure" src="https://github.com/Snowflake-Labs/snowflake-cli/assets/156019931/cbccbe4e-0c98-41d4-bbbe-d0332412247d">

<img width="1804" alt="qualified-success" src="https://github.com/Snowflake-Labs/snowflake-cli/assets/156019931/901f6ad6-5b7a-4a47-bbcc-371e6b3b5278">

**Precedent from object commands**:
<img width="1472" alt="describe-precedent" src="https://github.com/Snowflake-Labs/snowflake-cli/assets/156019931/1df5d9bd-29d1-406c-8051-eea4735fce66">

