### PR TITLE
Redirected stderr to PIPE in docker_registry_login so error output is properly captured

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -5,7 +5,7 @@
 ## New additions
 
 ## Fixes and improvements
-
+* Fixed errors during `spcs image-registry login` not being formatted correctly.
 
 # v2.1.0
 

--- a/src/snowflake/cli/plugins/spcs/image_registry/manager.py
+++ b/src/snowflake/cli/plugins/spcs/image_registry/manager.py
@@ -82,6 +82,8 @@ class RegistryManager(SqlExecutionMixin):
             registry_url,
         ]
         try:
-            return subprocess.check_output(command, input=json.dumps(token), text=True)
+            return subprocess.check_output(
+                command, input=json.dumps(token), text=True, stderr=subprocess.PIPE
+            )
         except subprocess.CalledProcessError as e:
             raise ClickException(f"Login Failed: {e.stderr}".strip())

--- a/tests/spcs/test_registry.py
+++ b/tests/spcs/test_registry.py
@@ -1,5 +1,5 @@
 import json
-from subprocess import CalledProcessError
+from subprocess import CalledProcessError, PIPE
 from unittest import mock
 
 import pytest
@@ -139,7 +139,7 @@ def test_docker_registry_login(mock_check_output, mock_get_url, mock_get_token):
 
     result = RegistryManager().docker_registry_login()
     mock_check_output.assert_called_once_with(
-        expected_command, input=json.dumps(test_token), text=True
+        expected_command, input=json.dumps(test_token), text=True, stderr=PIPE
     )
     mock_get_url.assert_called_once_with()
     mock_get_token.assert_called_once_with()

--- a/tests/spcs/test_registry.py
+++ b/tests/spcs/test_registry.py
@@ -1,5 +1,5 @@
 import json
-from subprocess import CalledProcessError, PIPE
+from subprocess import PIPE, CalledProcessError
 from unittest import mock
 
 import pytest


### PR DESCRIPTION

### Pre-review checklist
   * [x] I've confirmed that instructions included in README.md are still correct after my changes in the codebase.
   * [x] I've added or updated automated unit tests to verify correctness of my new code.
   * [ ] I've added or updated integration tests to verify correctness of my new code.
   * [x] I've confirmed that my changes are working by executing CLI's commands manually.
   * [x] I've confirmed that my changes are up-to-date with the target branch.
   * [x] I've described my changes in the release notes.
   * [x] I've described my changes in the section below.

### Changes description
Previously, there was a bug that errors that occured during `docker login` when using `image-registry login` would appear above the ClickException output. This PR fixes that by properly capturing the error output and putting it into the ClickException message.

**Old**
<img width="1836" alt="old-error" src="https://github.com/Snowflake-Labs/snowflake-cli/assets/156019931/96ac32dc-5a5a-4d1b-b451-070b46ef9ebf">

**New**
<img width="1841" alt="new-error" src="https://github.com/Snowflake-Labs/snowflake-cli/assets/156019931/e628b419-7ce8-4434-97e3-6adba0b85d3b">

